### PR TITLE
Fixed remaining ESLint issues

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -67,6 +67,9 @@ module.exports = function (grunt) {
       }
     },
     eslint: {
+      options: {
+        quiet: true
+      },
       target: [
         '<%= files.server %>',
         '<%= files.grunt %>',

--- a/test/unit/middleware/source_files.spec.js
+++ b/test/unit/middleware/source_files.spec.js
@@ -3,7 +3,6 @@ var mocks = require('mocks')
 var request = require('supertest-as-promised')
 var helper = require('../../../lib/helper')
 var File = require('../../../lib/file')
-var Url = require('../../../lib/url')
 var createServeFile = require('../../../lib/middleware/common').createServeFile
 var createSourceFilesMiddleware = require('../../../lib/middleware/source_files').create
 
@@ -47,17 +46,13 @@ describe('middleware.source_files', function () {
 
   beforeEach(function () {
     files = helper.defer()
-    return server = createServer(files, serveFile, '/base/path')
+    server = createServer(files, serveFile, '/base/path')
+    return server
   })
 
   afterEach(function () {
     return next.reset()
   })
-
-  // helpers
-  var includedFiles = function (list) {
-    return files.resolve({included: list, served: []})
-  }
 
   var servedFiles = function (list) {
     return files.resolve({included: [], served: list})

--- a/test/unit/middleware/strip_host.spec.js
+++ b/test/unit/middleware/strip_host.spec.js
@@ -1,38 +1,16 @@
 describe('middleware.strip_host', function () {
-  var filesDeferred
   var nextSpy
-  var response
   var mocks = require('mocks')
-  var HttpResponseMock = mocks.http.ServerResponse
   var HttpRequestMock = mocks.http.ServerRequest
 
-  var File = require('../../../lib/file')
-  var Url = require('../../../lib/url')
-
-  var fsMock = mocks.fs.create({
-    base: {
-      path: {
-        'a.js': mocks.fs.file(0, 'js-src-a'),
-        'index.html': mocks.fs.file(0, '<html>')
-      }
-    },
-    src: {
-      'some.js': mocks.fs.file(0, 'js-source')
-    },
-    'utf8ášč': {
-      'some.js': mocks.fs.file(0, 'utf8-file')
-    }
-  })
-
-  var serveFile = require('../../../lib/middleware/common').createServeFile(fsMock, null)
   var createStripHostMiddleware = require('../../../lib/middleware/strip_host').create
 
-  var handler = filesDeferred = nextSpy = response = null
+  var handler = nextSpy = null
 
   beforeEach(function () {
     nextSpy = sinon.spy()
-    var request = null
-    return handler = createStripHostMiddleware(null, null, '/base/path')
+    handler = createStripHostMiddleware(null, null, '/base/path')
+    return handler
   })
 
   it('should strip request with IP number', function (done) {

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -6,7 +6,8 @@ describe('reporter', function () {
   var m = null
 
   beforeEach(function () {
-    return m = loadFile(__dirname + '/../../../lib/reporters/base.js')
+    m = loadFile(__dirname + '/../../../lib/reporters/base.js')
+    return m
   })
 
   return describe('Progress', function () {
@@ -15,7 +16,8 @@ describe('reporter', function () {
 
     beforeEach(function () {
       adapter = sinon.spy()
-      return reporter = new m.BaseReporter(null, null, adapter)
+      reporter = new m.BaseReporter(null, null, adapter)
+      return reporter
     })
 
     it('should write to all registered adapters', function () {


### PR DESCRIPTION
- Remove unused variables
- Add `quiet` to `grunt-eslint` to suppress warnings.
